### PR TITLE
added max_cpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ __***Follow steps 1-3 above then do the following:***__
 | rwr_convergence_tolerence | 0.0001 | Frobenius norm tolerence of spreadsheet vector in random walk(needed in DRaWR and Net Path)|
 | rwr_restart_probability | 0.5 | alpha in `V_(n+1) = alpha * N * Vn + (1-alpha) * Vo` (needed in DRaWR and Net Path) |
 | k_space| 100| number of the new space dimensions in SVD(only needed in Net Path)|
+| max_cpu | 4| Maximum number of processors to use |
 
 pg_network_name = kegg_pathway_property_gene.edge</br>
 gg_network_name = STRING_experimental_gene_gene.edge</br>

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM knowengdev/base_image:09_19_2017
+FROM knowengdev/base_image:08_01_2018
 LABEL Xi Chen="xichen24@illinois.edu" \
       Jing Ge="jingge2@illinois.edu" \
       Dan Lanier="lanier4@illinois.edu" \

--- a/data/run_files/BENCHMARK_1_fisher.yml
+++ b/data/run_files/BENCHMARK_1_fisher.yml
@@ -1,11 +1,11 @@
 # ------------------------------------------------------------------------------------------------------
 # - Analysis Method: fisher, DRaWR, net_path                                                           -
 # ------------------------------------------------------------------------------------------------------
-method: fisher                        
+method:                     fisher
 
 pg_network_name_full_path:  ../data/networks/kegg_pathway_property_gene.edge
 spreadsheet_name_full_path: ../data/spreadsheets/ProGENI_rwr20_STExp_GDSC_500.rname.gxc.tsv
-gene_names_map: ../data/spreadsheets/ProGENI_rwr20_STExp_GDSC_500_MAP.rname.gxc.tsv
+gene_names_map:             ../data/spreadsheets/ProGENI_rwr20_STExp_GDSC_500_MAP.rname.gxc.tsv
 
 results_directory:          ./run_dir/results
-
+max_cpu:                    4

--- a/data/run_files/BENCHMARK_2_DRaWR.yml
+++ b/data/run_files/BENCHMARK_2_DRaWR.yml
@@ -1,16 +1,16 @@
 # ------------------------------------------------------------------------------------------------------
 # - Analysis Method: fisher, DRaWR, net_path                                                           -
 # ------------------------------------------------------------------------------------------------------
-method: DRaWR                        
+method:                     DRaWR
 
 gg_network_name_full_path:  ../data/networks/STRING_experimental_gene_gene.edge
 pg_network_name_full_path:  ../data/networks/kegg_pathway_property_gene.edge
 spreadsheet_name_full_path: ../data/spreadsheets/ProGENI_rwr20_STExp_GDSC_500.rname.gxc.tsv
-gene_names_map: ../data/spreadsheets/ProGENI_rwr20_STExp_GDSC_500_MAP.rname.gxc.tsv
+gene_names_map:             ../data/spreadsheets/ProGENI_rwr20_STExp_GDSC_500_MAP.rname.gxc.tsv
 
-results_directory:           ./run_dir/results
+results_directory:          ./run_dir/results
 
 rwr_max_iterations:         500
 rwr_convergence_tolerence:  1.0e-4
 rwr_restart_probability:    0.5       # Vn+1 = alpha * N * Vn + (1-alpha) * Vo
-
+max_cpu:                    4

--- a/data/run_files/BENCHMARK_3_net_path.yml
+++ b/data/run_files/BENCHMARK_3_net_path.yml
@@ -1,12 +1,12 @@
 # ------------------------------------------------------------------------------------------------------
 # - Analysis Method: fisher, DRaWR, net_svds                                                           -
 # ------------------------------------------------------------------------------------------------------
-method: net_svds                        
+method:                      net_svds
 
 gg_network_name_full_path:   ../data/networks/STRING_experimental_gene_gene.edge
 pg_network_name_full_path:   ../data/networks/kegg_pathway_property_gene.edge
 spreadsheet_name_full_path:  ../data/spreadsheets/ProGENI_rwr20_STExp_GDSC_500.rname.gxc.tsv
-gene_names_map: ../data/spreadsheets/ProGENI_rwr20_STExp_GDSC_500_MAP.rname.gxc.tsv
+gene_names_map:              ../data/spreadsheets/ProGENI_rwr20_STExp_GDSC_500_MAP.rname.gxc.tsv
 
 results_directory:           ./run_dir/results
 
@@ -14,5 +14,5 @@ rwr_max_iterations:          500
 rwr_convergence_tolerence:   1.0e-4
 rwr_restart_probability:     0.5        # Vn+1 = alpha * N * Vn + (1-alpha) * Vo
 
-k_space: 100                            # number of dimensions of the new space in SVD
-
+k_space:                     100        # number of dimensions of the new space in SVD
+max_cpu:                     4

--- a/data/run_files/TEST_1_fisher.yml
+++ b/data/run_files/TEST_1_fisher.yml
@@ -1,11 +1,11 @@
 # ------------------------------------------------------------------------------------------------------
 # - Analysis Method: fisher, DRaWR, net_path                                                           -
 # ------------------------------------------------------------------------------------------------------
-method: fisher                        
+method:                     fisher
 
 pg_network_name_full_path:  ../data/networks/TEST_1_property_gene.edge
 spreadsheet_name_full_path: ../data/spreadsheets/TEST_1_spreadsheet.tsv
-gene_names_map: ../data/spreadsheets/TEST_1_spreadsheet_MAP.tsv
+gene_names_map:             ../data/spreadsheets/TEST_1_spreadsheet_MAP.tsv
 
 results_directory:          ./run_dir/results
-
+max_cpu:                    4

--- a/data/run_files/TEST_2_DRaWR.yml
+++ b/data/run_files/TEST_2_DRaWR.yml
@@ -1,16 +1,16 @@
 # ------------------------------------------------------------------------------------------------------
 # - Analysis Method: fisher, DRaWR, net_path                                                           -
 # ------------------------------------------------------------------------------------------------------
-method: DRaWR                        
+method:                     DRaWR                        
 
 gg_network_name_full_path:  ../data/networks/TEST_1_gene_gene.edge
 pg_network_name_full_path:  ../data/networks/TEST_1_property_gene.edge
 spreadsheet_name_full_path: ../data/spreadsheets/TEST_1_spreadsheet.tsv
-gene_names_map: ../data/spreadsheets/TEST_1_spreadsheet_MAP.tsv
+gene_names_map:             ../data/spreadsheets/TEST_1_spreadsheet_MAP.tsv
 
-results_directory:           ./run_dir/results
+results_directory:          ./run_dir/results
 
 rwr_max_iterations:         500
 rwr_convergence_tolerence:  1.0e-4
 rwr_restart_probability:    0.5       # Vn+1 = alpha * N * Vn + (1-alpha) * Vo
-
+max_cpu:                    4

--- a/data/run_files/TEST_3_net_path.yml
+++ b/data/run_files/TEST_3_net_path.yml
@@ -1,12 +1,12 @@
 # ------------------------------------------------------------------------------------------------------
 # - Analysis Method: fisher, DRaWR, net_svds                                                           -
 # ------------------------------------------------------------------------------------------------------
-method: net_svds                        
+method:                      net_svds
 
 gg_network_name_full_path:   ../data/networks/TEST_1_gene_gene.edge
 pg_network_name_full_path:   ../data/networks/TEST_1_property_gene.edge
 spreadsheet_name_full_path:  ../data/spreadsheets/TEST_1_spreadsheet.tsv
-gene_names_map: ../data/spreadsheets/TEST_1_spreadsheet_MAP.tsv
+gene_names_map:              ../data/spreadsheets/TEST_1_spreadsheet_MAP.tsv
 
 results_directory:           ./run_dir/results
 
@@ -14,5 +14,5 @@ rwr_max_iterations:          500
 rwr_convergence_tolerence:   1.0e-4
 rwr_restart_probability:     0.5        # Vn+1 = alpha * N * Vn + (1-alpha) * Vo
 
-k_space: 2                              # number of dimensions of the new space in SVD
-
+k_space:                     2          # number of dimensions of the new space in SVD
+max_cpu:                     4

--- a/data/run_files/zTEMPLATE_net_path.yml
+++ b/data/run_files/zTEMPLATE_net_path.yml
@@ -1,7 +1,7 @@
 # ------------------------------------------------------------------------------------------------------
 # - Analysis Method: fisher, DRaWR, net_path                                                           -
 # ------------------------------------------------------------------------------------------------------
-method: net_path
+method:                     net_path
 
 # --------------------------------------------------------------------
 # - 4 col edge adjacency dataframe in .tsv format                    -
@@ -11,7 +11,7 @@ method: net_path
 gg_network_name_full_path:  ../data/networks/STRING_experimental_gene_gene.edge
 pg_network_name_full_path:  ../data/networks/kegg_pathway_property_gene.edge
 spreadsheet_name_full_path: ../data/spreadsheets/ProGENI_rwr20_STExp_GDSC_500.rname.gxc.tsv
-gene_names_map: ../data/spreadsheets/ProGENI_rwr20_STExp_GDSC_500_MAP.rname.gxc.tsv
+gene_names_map:             ../data/spreadsheets/ProGENI_rwr20_STExp_GDSC_500_MAP.rname.gxc.tsv
 
 # --------------------------------------------------------------------
 # - directory where the result files will be written                 -
@@ -30,5 +30,5 @@ rwr_restart_probability:    0.5
 # --------------------------------------------------------------------
 # - number of dimensions of the new space in SVD                     -
 # --------------------------------------------------------------------
-k_space: 100                            
-
+k_space:                    100                            
+max_cpu:                    4

--- a/src/geneset_characterization_toolbox.py
+++ b/src/geneset_characterization_toolbox.py
@@ -74,7 +74,8 @@ def run_fisher(run_parameters):
 
     fisher_contingency_pval = get_fisher_exact_test           ( prop_gene_network_sparse
                                                               , reverse_prop_dict
-                                                              , new_spreadsheet_df  )
+                                                              , new_spreadsheet_df
+                                                              , run_parameters['max_cpu']  )
 
     fisher_final_result     = save_fisher_test_result         ( fisher_contingency_pval
                                                               , run_parameters['results_directory']
@@ -366,13 +367,14 @@ def build_fisher_contingency_table(overlap_count, user_count, gene_count, count)
 fisher_contingency_pval_parallel_insertion = []
 
 
-def get_fisher_exact_test(prop_gene_network_sparse, sparse_dict, spreadsheet_df):
+def get_fisher_exact_test(prop_gene_network_sparse, sparse_dict, spreadsheet_df, max_cpu):
     """ central loop: compute components for fisher exact test.
 
     Args:
         prop_gene_network_sparse: sparse matrix of network gene set.
         sparse_dict: look up table of sparse matrix.
         spreadsheet_df: the dataframe of user gene set.
+        max_cpu: the maximum number of processors to use.
 
     Returns:
         fisher_contingency_pval: list of seven items lists.
@@ -385,7 +387,7 @@ def get_fisher_exact_test(prop_gene_network_sparse, sparse_dict, spreadsheet_df)
 
     dimension      = [range(overlap_count.shape[0]), range(overlap_count.shape[1])]
     combinations   = list(itertools.product(*dimension))
-    parallelism    = dstutil.determine_parallelism_locally(len(combinations))
+    parallelism    = dstutil.determine_parallelism_locally(min(max_cpu, len(combinations)))
 
    #----
     try:


### PR DESCRIPTION
These changes add a max_cpu parameter to match GP and FP. Only fisher was creating a worker pool, so it's the only mode affected.

I ran `make run_fisher run_drawr run_netpath run_fisher_small run_drawr_small run_netpath_small` with this version and confirmed all output files were identical to those produced by knowengdev/geneset_characterization_pipeline:03_12_2018, which is the version currently used in production and which predates all max_cpu changes.

Also note that `make unit_tests` fails in both this new version and in the reference version:

```
unit tests fail in reference:

root@3eff690e0fba:/home/test# make unit_test_setup unit_tests
mkdir -p  ./unit/tmp
cd unit; make all_unit_tests
make[1]: Entering directory `/home/test/unit'
PYTHONPATH='../../src/' python3 -m unittest discover --pattern=test_*.py
.EE.....
======================================================================
ERROR: test_perform_k_SVD (test_calculate_k_SVD.TestPerform_k_SVD)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/test/unit/test_calculate_k_SVD.py", line 16, in test_perform_k_SVD
    ret_U, ret_S = tl.calculate_k_SVD(self.smooth_spreadsheet_matrix, self.k)
AttributeError: 'module' object has no attribute 'calculate_k_SVD'

======================================================================
ERROR: test_perform_net_path (test_get_net_path_results.TestPerform_net_path)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/test/unit/test_get_net_path_results.py", line 23, in test_perform_net_path
    ret = tl.get_net_path_results(self.gene_length, self.smooth_rwr_matrix, self.run_parameters)
  File "/home/src/geneset_characterization_toolbox.py", line 227, in get_net_path_results
    calculate_k_SVDS(smooth_rwr_matrix, int(run_parameters['k_space']))
  File "/home/src/geneset_characterization_toolbox.py", line 158, in calculate_k_SVDS
    U_unitary_matrix, singular_value, V_unitary_matrix = svds(sparse_smooth_spreadsheet_matrix,k)
  File "/usr/local/lib/python3.4/dist-packages/scipy/sparse/linalg/eigen/arpack/arpack.py", line 1714, in svds
    raise ValueError("k must be between 1 and min(A.shape), k=%d" % k)
ValueError: k must be between 1 and min(A.shape), k=2

----------------------------------------------------------------------
Ran 8 tests in 0.105s

FAILED (errors=2)
make[1]: *** [all_unit_tests] Error 1
make[1]: Leaving directory `/home/test/unit'
make: *** [unit_tests] Error 2
```